### PR TITLE
Feature/auth: 회원가입, 로그아웃, 토큰 갱신, strategy 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/core": "^10.0.0",
         "@nestjs/jwt": "^10.2.0",
         "@nestjs/mapped-types": "^2.0.6",
+        "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/swagger": "^8.0.7",
         "@nestjs/typeorm": "^10.0.2",
@@ -2725,6 +2726,16 @@
         "class-validator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/passport": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-10.0.3.tgz",
+      "integrity": "sha512-znJ9Y4S8ZDVY+j4doWAJ8EuuVO7SkQN3yOBmzxbGaXbvcSwFDAdGJ+OMCg52NdzIO4tQoN4pYKx8W6M0ArfFRQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "passport": "^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0"
       }
     },
     "node_modules/@nestjs/platform-express": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "passport-oauth2": "^1.8.0",
+        "passport-strategy": "^1.0.0",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
         "swagger-ui-express": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "passport-oauth2": "^1.8.0",
+    "passport-strategy": "^1.0.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
     "swagger-ui-express": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/mapped-types": "^2.0.6",
+    "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/swagger": "^8.0.7",
     "@nestjs/typeorm": "^10.0.2",

--- a/src/application/auth/auth.controller.ts
+++ b/src/application/auth/auth.controller.ts
@@ -9,6 +9,8 @@ import { AuthGuard } from '@nestjs/passport';
 import { SocialLoginGuard } from './guards/socialLogin.guard';
 import { UserService } from 'src/domain/user/user.service';
 import { Cookie } from './decorators/cookie.decorator';
+import { User } from 'src/common/decorators/user.decorator';
+import { UserPayload } from 'src/common/interfaces/user.payload';
 
 @Controller('auth')
 @ApiTags('auth')
@@ -48,8 +50,8 @@ export class AuthController {
   @Post('refresh-token')
   @UseGuards(AuthGuard('jwt-refresh'))
   @Docs('refresh-token')
-  async renewToken(@Req() req: any) {
-    const id = req.user.id;
+  async renewToken(@User() user: UserPayload) {
+    const id = user.id;
     return await this.authService.renewToken(id);
   }
 

--- a/src/application/auth/auth.controller.ts
+++ b/src/application/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, Req, Res } from '@nestjs/common';
+import { Body, Controller, Post, Req, Res, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { AuthService } from './auth.service';
@@ -6,6 +6,7 @@ import { SocialLoginReqDto } from './dtos/socialLogin.dto';
 import { CookieConfig } from './configs/cookie.config';
 import { RegisterReqDto } from './dtos/register.dto';
 import { Docs } from './docs/auth.decorator';
+import { AuthGuard } from '@nestjs/passport';
 
 @Controller('auth')
 @ApiTags('auth')
@@ -41,8 +42,10 @@ export class AuthController {
   }
 
   @Post('refresh-token')
-  async renewToken() {
-    
+  @UseGuards(AuthGuard('jwt-refresh'))
+  async renewToken(@Req() req: any) {
+    const id = req.user.id;
+    return await this.authService.renewToken(id);
   }
 
   @Post('logout')

--- a/src/application/auth/auth.controller.ts
+++ b/src/application/auth/auth.controller.ts
@@ -26,7 +26,7 @@ export class AuthController {
     return res.json({ isOnboarding });
   }
 
-  @Post('regiser')
+  @Post('register')
   async register(@Body() registerReqDto: RegisterReqDto, @Req() req: Request, @Res() res: Response) {
     const id = req.cookies['sub'];
     const { accessToken, refreshToken } = await this.authService.register(id, registerReqDto);

--- a/src/application/auth/auth.controller.ts
+++ b/src/application/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import { CookieConfig } from './configs/cookie.config';
 import { RegisterReqDto } from './dtos/register.dto';
 import { Docs } from './docs/auth.decorator';
 import { AuthGuard } from '@nestjs/passport';
+import { SocialLoginGuard } from './guards/socialLogin.guard';
 
 @Controller('auth')
 @ApiTags('auth')
@@ -16,9 +17,12 @@ export class AuthController {
   ) { }
 
   @Post('social-login')
+  @UseGuards(SocialLoginGuard)
   @Docs('social-login')
-  async socialLogin(@Body() socialLoginReqDto: SocialLoginReqDto, @Res() res: Response) {
-    const { id, isOnboarding } = await this.authService.socialLogin(socialLoginReqDto);
+  async socialLogin(@Body() socialLoginReqDto: SocialLoginReqDto, @Res() res: Response, @Req() req: any) {
+    const oauthId = req.oauthId;
+    const { id, isOnboarding } = await this.authService.socialLogin(oauthId);
+    // const { id, isOnboarding } = await this.authService.socialLogin(socialLoginReqDto);
     if (!isOnboarding) {
       const refreshToken = await this.authService.generateRefreshToken(id);
       res.cookie('refresh-token', refreshToken, CookieConfig.refreshToken);

--- a/src/application/auth/auth.controller.ts
+++ b/src/application/auth/auth.controller.ts
@@ -21,7 +21,7 @@ export class AuthController {
   @UseGuards(SocialLoginGuard)
   @Docs('social-login')
   async socialLogin(@Res() res: Response, @Req() req: any) {
-    const oauthId = req.oauthId;
+    const oauthId = req.user;
     const { id, isOnboarding } = await this.userService.getOrCreateUser(oauthId);
     if (!isOnboarding) {
       const refreshToken = await this.authService.generateRefreshToken(id);

--- a/src/application/auth/auth.controller.ts
+++ b/src/application/auth/auth.controller.ts
@@ -49,7 +49,10 @@ export class AuthController {
   }
 
   @Post('logout')
-  async logout() {
-
+  @UseGuards(AuthGuard('jwt-refresh'))
+  async logout(@Res() res: Response) {
+    res.clearCookie('refresh-token', CookieConfig.refreshToken);
+    
+    return res.send();
   }
 }

--- a/src/application/auth/auth.controller.ts
+++ b/src/application/auth/auth.controller.ts
@@ -35,7 +35,7 @@ export class AuthController {
     const id = req.cookies['sub'];
     const { accessToken, refreshToken } = await this.authService.register(id, registerReqDto);
 
-    res.clearCookie('sub', CookieConfig.onboardingToken);
+    res.clearCookie('sub', CookieConfig.tokenDelete);
     res.cookie('refresh-token', refreshToken, CookieConfig.refreshToken);
 
     return res.json({ accessToken });
@@ -51,7 +51,7 @@ export class AuthController {
   @Post('logout')
   @UseGuards(AuthGuard('jwt-refresh'))
   async logout(@Res() res: Response) {
-    res.clearCookie('refresh-token', CookieConfig.refreshToken);
+    res.clearCookie('refresh-token', CookieConfig.tokenDelete);
     
     return res.send();
   }

--- a/src/application/auth/auth.controller.ts
+++ b/src/application/auth/auth.controller.ts
@@ -4,10 +4,11 @@ import { Request, Response } from 'express';
 import { AuthService } from './auth.service';
 import { CookieConfig } from './configs/cookie.config';
 import { RegisterReqDto } from './dtos/register.dto';
-import { Docs } from './docs/auth.decorator';
+import { Docs } from './decorators/docs/auth.decorator';
 import { AuthGuard } from '@nestjs/passport';
 import { SocialLoginGuard } from './guards/socialLogin.guard';
 import { UserService } from 'src/domain/user/user.service';
+import { Cookie } from './decorators/cookie.decorator';
 
 @Controller('auth')
 @ApiTags('auth')
@@ -35,8 +36,7 @@ export class AuthController {
 
   @Post('register')
   @Docs('register')
-  async register(@Body() registerReqDto: RegisterReqDto, @Req() req: Request, @Res() res: Response) {
-    const id = req.cookies['sub'];
+  async register(@Body() registerReqDto: RegisterReqDto, @Cookie('sub') id: number, @Res() res: Response) {
     const { accessToken, refreshToken } = await this.authService.register(id, registerReqDto);
 
     res.clearCookie('sub', CookieConfig.tokenDelete);

--- a/src/application/auth/auth.controller.ts
+++ b/src/application/auth/auth.controller.ts
@@ -5,6 +5,7 @@ import { AuthService } from './auth.service';
 import { SocialLoginReqDto } from './dtos/socialLogin.dto';
 import { CookieConfig } from './configs/cookie.config';
 import { RegisterReqDto } from './dtos/register.dto';
+import { Docs } from './docs/auth.decorator';
 
 @Controller('auth')
 @ApiTags('auth')
@@ -14,6 +15,7 @@ export class AuthController {
   ) { }
 
   @Post('social-login')
+  @Docs('social-login')
   async socialLogin(@Body() socialLoginReqDto: SocialLoginReqDto, @Res() res: Response) {
     const { id, isOnboarding } = await this.authService.socialLogin(socialLoginReqDto);
     if (!isOnboarding) {
@@ -27,6 +29,7 @@ export class AuthController {
   }
 
   @Post('register')
+  @Docs('register')
   async register(@Body() registerReqDto: RegisterReqDto, @Req() req: Request, @Res() res: Response) {
     const id = req.cookies['sub'];
     const { accessToken, refreshToken } = await this.authService.register(id, registerReqDto);

--- a/src/application/auth/auth.controller.ts
+++ b/src/application/auth/auth.controller.ts
@@ -43,6 +43,7 @@ export class AuthController {
 
   @Post('refresh-token')
   @UseGuards(AuthGuard('jwt-refresh'))
+  @Docs('refresh-token')
   async renewToken(@Req() req: any) {
     const id = req.user.id;
     return await this.authService.renewToken(id);
@@ -50,6 +51,7 @@ export class AuthController {
 
   @Post('logout')
   @UseGuards(AuthGuard('jwt-refresh'))
+  @Docs('logout')
   async logout(@Res() res: Response) {
     res.clearCookie('refresh-token', CookieConfig.tokenDelete);
     

--- a/src/application/auth/auth.controller.ts
+++ b/src/application/auth/auth.controller.ts
@@ -8,21 +8,22 @@ import { RegisterReqDto } from './dtos/register.dto';
 import { Docs } from './docs/auth.decorator';
 import { AuthGuard } from '@nestjs/passport';
 import { SocialLoginGuard } from './guards/socialLogin.guard';
+import { UserService } from 'src/domain/user/user.service';
 
 @Controller('auth')
 @ApiTags('auth')
 export class AuthController {
   constructor(
-    private readonly authService: AuthService
+    private readonly authService: AuthService,
+    private readonly userService: UserService
   ) { }
 
   @Post('social-login')
   @UseGuards(SocialLoginGuard)
   @Docs('social-login')
-  async socialLogin(@Body() socialLoginReqDto: SocialLoginReqDto, @Res() res: Response, @Req() req: any) {
+  async socialLogin(@Res() res: Response, @Req() req: any) {
     const oauthId = req.oauthId;
-    const { id, isOnboarding } = await this.authService.socialLogin(oauthId);
-    // const { id, isOnboarding } = await this.authService.socialLogin(socialLoginReqDto);
+    const { id, isOnboarding } = await this.userService.getOrCreateUser(oauthId);
     if (!isOnboarding) {
       const refreshToken = await this.authService.generateRefreshToken(id);
       res.cookie('refresh-token', refreshToken, CookieConfig.refreshToken);

--- a/src/application/auth/auth.controller.ts
+++ b/src/application/auth/auth.controller.ts
@@ -2,7 +2,6 @@ import { Body, Controller, Post, Req, Res, UseGuards } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { AuthService } from './auth.service';
-import { SocialLoginReqDto } from './dtos/socialLogin.dto';
 import { CookieConfig } from './configs/cookie.config';
 import { RegisterReqDto } from './dtos/register.dto';
 import { Docs } from './docs/auth.decorator';

--- a/src/application/auth/auth.module.ts
+++ b/src/application/auth/auth.module.ts
@@ -5,13 +5,14 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { UserService } from 'src/domain/user/user.service';
 import { User } from 'src/domain/user/entities/user.entity';
+import { JwtRefreshStrategy } from './strategies/jwtRefresh.strategy';
 
 @Module({
   imports:[
     TypeOrmModule.forFeature([User]),
     JwtModule.register({})
   ],
-  providers: [AuthService, UserService],
+  providers: [AuthService, UserService, JwtRefreshStrategy],
   controllers: [AuthController]
 })
 export class AuthModule {}

--- a/src/application/auth/auth.module.ts
+++ b/src/application/auth/auth.module.ts
@@ -6,13 +6,15 @@ import { AuthController } from './auth.controller';
 import { UserService } from 'src/domain/user/user.service';
 import { User } from 'src/domain/user/entities/user.entity';
 import { JwtRefreshStrategy } from './strategies/jwtRefresh.strategy';
+import { KakaoStrategy } from './strategies/kakao.strategy';
+import { SocialLoginGuard } from './guards/socialLogin.guard';
 
 @Module({
   imports:[
     TypeOrmModule.forFeature([User]),
     JwtModule.register({})
   ],
-  providers: [AuthService, UserService, JwtRefreshStrategy],
+  providers: [AuthService, UserService, JwtRefreshStrategy, KakaoStrategy, SocialLoginGuard],
   controllers: [AuthController]
 })
 export class AuthModule {}

--- a/src/application/auth/auth.service.ts
+++ b/src/application/auth/auth.service.ts
@@ -24,6 +24,12 @@ export class AuthService {
     return tokens;
   }
 
+  async renewToken(id: number) {
+    const accessToken = this.generateAccessToken(id);
+
+    return { accessToken };
+  } 
+
   async socialLogin(socialLoginReqDto: SocialLoginReqDto) {
     const { code, provider } = socialLoginReqDto;
     let oauthId = "";
@@ -39,7 +45,7 @@ export class AuthService {
   }
 
   generateAccessToken(id: number): string {
-    const payload = { id };
+    const payload = { sub: id };
     const accessToken = this.jwtService.sign(payload, {
       secret: process.env.JWT_ACCESS_SECRET,
       expiresIn: process.env.JWT_ACCESS_EXPIRES_IN,
@@ -49,7 +55,7 @@ export class AuthService {
   }
 
   async generateRefreshToken(id: number): Promise<string> {
-    const payload = { id };
+    const payload = { sub: id };
     const refreshToken = this.jwtService.sign(payload, {
       secret: process.env.JWT_REFRESH_SECRET,
       expiresIn: process.env.JWT_REFRESH_EXPIRES_IN,

--- a/src/application/auth/auth.service.ts
+++ b/src/application/auth/auth.service.ts
@@ -20,7 +20,7 @@ export class AuthService {
   async register(id: number, registerReqDto: RegisterReqDto) {
     await this.userService.updateUser(id, registerReqDto);
     const tokens = await this.generateTokens(id);
-
+    
     return tokens;
   }
 

--- a/src/application/auth/auth.service.ts
+++ b/src/application/auth/auth.service.ts
@@ -26,12 +26,6 @@ export class AuthService {
     const accessToken = this.generateAccessToken(id);
 
     return { accessToken };
-  } 
-
-  async socialLogin(oauthId: string) {
-    const user = await this.userService.getOrCreateUser(oauthId);
-
-    return { id: user.id, isOnboarding: user.isOnboarding };
   }
 
   generateAccessToken(id: number): string {

--- a/src/application/auth/auth.service.ts
+++ b/src/application/auth/auth.service.ts
@@ -30,7 +30,8 @@ export class AuthService {
     return { accessToken };
   } 
 
-  async socialLogin(socialLoginReqDto: SocialLoginReqDto) {
+  async socialLogin(oauthId: string) {
+    /*
     const { code, provider } = socialLoginReqDto;
     let oauthId = "";
 
@@ -39,6 +40,7 @@ export class AuthService {
         const kakaoToken = await this.getKakaoToken(code);
         oauthId = (await this.getKakaoUserInfo(kakaoToken)).toString();
     }
+        */
     const user = await this.userService.getOrCreateUser(oauthId);
 
     return { id: user.id, isOnboarding: user.isOnboarding };

--- a/src/application/auth/auth.service.ts
+++ b/src/application/auth/auth.service.ts
@@ -17,8 +17,11 @@ export class AuthService {
     private jwtService: JwtService,
   ) { }
 
-  async register(registerReqDto: RegisterReqDto) {
-    
+  async register(id: number, registerReqDto: RegisterReqDto) {
+    await this.userService.updateUser(id, registerReqDto);
+    const tokens = await this.generateTokens(id);
+
+    return tokens;
   }
 
   async socialLogin(socialLoginReqDto: SocialLoginReqDto) {
@@ -53,6 +56,13 @@ export class AuthService {
     });
 
     return refreshToken;
+  }
+
+  async generateTokens(id: number) {
+    const accessToken = this.generateAccessToken(id);
+    const refreshToken = await this.generateRefreshToken(id);
+
+    return { accessToken, refreshToken };
   }
 
   private async getKakaoToken(code: string): Promise<string> {

--- a/src/application/auth/auth.service.ts
+++ b/src/application/auth/auth.service.ts
@@ -1,10 +1,8 @@
-import { BadRequestException, Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { JwtService } from '@nestjs/jwt';
 import { User } from 'src/domain/user/entities/user.entity';
 import { Repository } from 'typeorm';
-import { SocialLoginReqDto } from './dtos/socialLogin.dto';
-import axios from 'axios';
 import { UserService } from 'src/domain/user/user.service';
 import { RegisterReqDto } from './dtos/register.dto';
 
@@ -31,16 +29,6 @@ export class AuthService {
   } 
 
   async socialLogin(oauthId: string) {
-    /*
-    const { code, provider } = socialLoginReqDto;
-    let oauthId = "";
-
-    switch (provider) {
-      case 'kakao':
-        const kakaoToken = await this.getKakaoToken(code);
-        oauthId = (await this.getKakaoUserInfo(kakaoToken)).toString();
-    }
-        */
     const user = await this.userService.getOrCreateUser(oauthId);
 
     return { id: user.id, isOnboarding: user.isOnboarding };
@@ -71,32 +59,5 @@ export class AuthService {
     const refreshToken = await this.generateRefreshToken(id);
 
     return { accessToken, refreshToken };
-  }
-
-  private async getKakaoToken(code: string): Promise<string> {
-    const params = {
-      grant_type: 'authorization_code',
-      client_id: process.env.KAKAO_CLIENT_ID,
-      redirect_uri: process.env.KAKAO_CALLBACK_URL,
-      code: code
-    }
-    const headers = { 'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8' };
-    const res = await axios.post('https://kauth.kakao.com/oauth/token', {}, { params, headers });
-    if (!res) throw new BadRequestException('Kakao access token을 가져오는데 실패 했습니다.');
-
-    const kakaoToken = res.data.access_token;
-    if (!kakaoToken) throw new UnauthorizedException("Kakao access token을 가져오는데 실패 했습니다.");
-
-    return kakaoToken;
-  }
-
-  private async getKakaoUserInfo(kakaoToken): Promise<string> {
-    const res = await axios.get('https://kapi.kakao.com/v2/user/me', { headers: { Authorization: `Bearer ${kakaoToken}` } });
-    if (!res) new UnauthorizedException("소셜 로그인 계정 정보를 불러올 수 없습니다.");
-
-    const id = res.data.id;
-    if (!id) throw new NotFoundException("존재하지 않는 소셜 로그인 유저 입니다.");
-
-    return id;
   }
 }

--- a/src/application/auth/configs/cookie.config.ts
+++ b/src/application/auth/configs/cookie.config.ts
@@ -13,4 +13,9 @@ export const CookieConfig = {
     sameSite: 'none',
     expires: new Date(Date.now() + 24 * 60 * 60 * 1000 * 30),
   } as CookieOptions,
+  onboardingToken: {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'none',
+  } as CookieOptions
 };

--- a/src/application/auth/configs/cookie.config.ts
+++ b/src/application/auth/configs/cookie.config.ts
@@ -17,5 +17,10 @@ export const CookieConfig = {
     httpOnly: true,
     secure: true,
     sameSite: 'none',
+  } as CookieOptions,
+  tokenDelete: {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'none',
   } as CookieOptions
 };

--- a/src/application/auth/decorators/cookie.decorator.ts
+++ b/src/application/auth/decorators/cookie.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const Cookie = createParamDecorator(
+  (key: string, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.cookies[key];
+  },
+);

--- a/src/application/auth/decorators/docs/auth.decorator.ts
+++ b/src/application/auth/decorators/docs/auth.decorator.ts
@@ -1,7 +1,7 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiBody, ApiConflictResponse, ApiCreatedResponse, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiUnauthorizedResponse } from '@nestjs/swagger';
-import { SocialLoginReqDto, SocialLoginResDto } from '../dtos/socialLogin.dto';
-import { RegisterReqDto, RegisterResDto } from '../dtos/register.dto';
+import { SocialLoginReqDto, SocialLoginResDto } from '../../dtos/socialLogin.dto';
+import { RegisterReqDto, RegisterResDto } from '../../dtos/register.dto';
 
 type EndPoints =
   | 'register'

--- a/src/application/auth/docs/auth.decorator.ts
+++ b/src/application/auth/docs/auth.decorator.ts
@@ -1,5 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiBody, ApiConflictResponse, ApiCreatedResponse, ApiNotFoundResponse, ApiOperation, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { ApiBody, ApiConflictResponse, ApiCreatedResponse, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiUnauthorizedResponse } from '@nestjs/swagger';
 import { SocialLoginReqDto, SocialLoginResDto } from '../dtos/socialLogin.dto';
 import { RegisterReqDto, RegisterResDto } from '../dtos/register.dto';
 
@@ -48,6 +48,27 @@ export function Docs(endPoint: EndPoints) {
       ApiNotFoundResponse({
         description: "존재하지 않는 사용자입니다."
       })
-    )
+    );
+    case 'refresh-token': return applyDecorators(
+      ApiOperation({
+        description: "access 토큰 갱신. cookie의 refresh token 확인하여 access token 갱신하여 반환",
+        summary: "access token 갱신"
+      }),
+      ApiCreatedResponse({
+        description: "토큰 갱신 성공"
+      }),
+      ApiUnauthorizedResponse({
+        description: "유효하지 않은 refresh token 입니다."
+      })
+    );
+    case 'logout': return applyDecorators(
+      ApiOperation({
+        description: "로그아웃. cookie의 refresh-token clear",
+        summary: "로그아웃"
+      }),
+      ApiOkResponse({
+        description: "로그아웃 성공"
+      })
+    );
   }
 }

--- a/src/application/auth/docs/auth.decorator.ts
+++ b/src/application/auth/docs/auth.decorator.ts
@@ -1,6 +1,7 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiBody, ApiCreatedResponse, ApiNotFoundResponse, ApiOperation, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { ApiBody, ApiConflictResponse, ApiCreatedResponse, ApiNotFoundResponse, ApiOperation, ApiUnauthorizedResponse } from '@nestjs/swagger';
 import { SocialLoginReqDto, SocialLoginResDto } from '../dtos/socialLogin.dto';
+import { RegisterReqDto, RegisterResDto } from '../dtos/register.dto';
 
 type EndPoints =
   | 'register'
@@ -12,7 +13,7 @@ export function Docs(endPoint: EndPoints) {
   switch (endPoint) {
     case 'social-login': return applyDecorators(
       ApiOperation({
-        description: "소셜 로그인. 인가 코드를 받아서 유저 온보딩 status return",
+        description: "소셜 로그인. 인가 코드를 받아서 유저 온보딩 status(isOnboarding) 반환",
         summary: "소셜 로그인"
       }),
       ApiBody({
@@ -29,5 +30,24 @@ export function Docs(endPoint: EndPoints) {
         description: "존재하지 않는 사용자"
       })
     );
+    case 'register': return applyDecorators(
+      ApiOperation({
+        description: "회원가입. 입력 정보들을 받아 회원가입. 완료 시 access token 반환",
+        summary: "회원가입"
+      }),
+      ApiBody({
+        type: RegisterReqDto
+      }),
+      ApiCreatedResponse({
+        description: "회원가입 완료",
+        type: RegisterResDto
+      }),
+      ApiConflictResponse({
+        description: "중복된 전화번호입니다."
+      }),
+      ApiNotFoundResponse({
+        description: "존재하지 않는 사용자입니다."
+      })
+    )
   }
 }

--- a/src/application/auth/dtos/register.dto.ts
+++ b/src/application/auth/dtos/register.dto.ts
@@ -23,4 +23,9 @@ class RegisterReqDto {
   account?: string;
 }
 
-export { RegisterReqDto }
+class RegisterResDto {
+  @ApiProperty({ example: "xxxx.xxxx.xxxx" })
+  accessToken: string;
+}
+
+export { RegisterReqDto, RegisterResDto }

--- a/src/application/auth/dtos/register.dto.ts
+++ b/src/application/auth/dtos/register.dto.ts
@@ -1,24 +1,24 @@
 import { ApiProperty } from '@nestjs/swagger';
-import {  IsOptional, IsString } from 'class-validator';
+import {  IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 class RegisterReqDto {
   @IsString()
-  @IsOptional()
+  @IsNotEmpty()
   @ApiProperty({ example: "이름" })
   name?: string;
 
   @IsString()
-  @IsOptional()
+  @IsNotEmpty()
   @ApiProperty({ example: "01000000000" })
   phone?: string;
 
   @IsString()
-  @IsOptional()
+  @IsNotEmpty()
   @ApiProperty({ example: "하나은행" })
   bank?: string;
 
   @IsString()
-  @IsOptional()
+  @IsNotEmpty()
   @ApiProperty({ example: "3333333333333" })
   account?: string;
 }

--- a/src/application/auth/dtos/register.dto.ts
+++ b/src/application/auth/dtos/register.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsNotEmpty, IsOptional, IsString, Length } from 'class-validator';
+import {  IsOptional, IsString } from 'class-validator';
 
 class RegisterReqDto {
   @IsString()

--- a/src/application/auth/guards/socialLogin.guard.ts
+++ b/src/application/auth/guards/socialLogin.guard.ts
@@ -1,23 +1,25 @@
 import { Injectable } from '@nestjs/common';
 import { ExecutionContext, CanActivate } from '@nestjs/common';
-import { KakaoStrategy } from '../strategies/kakao.strategy';
+import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
 export class SocialLoginGuard implements CanActivate {
-  constructor(
-    private readonly kakaoLoginStrategy: KakaoStrategy,
-  ) { }
+  constructor( ) { }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const req = context.switchToHttp().getRequest();
     const provider = req.body.provider;
+    const guard = this.getGuardbyProvider(provider);
 
+    return guard.canActivate(context) as Promise<boolean>;
+  }
+
+  private getGuardbyProvider(provider: string) {
     switch (provider) {
-      case "kakao":
-        await this.kakaoLoginStrategy.authenticate(req);
-        return true;
+      case 'kakao':
+        return new (AuthGuard('kakao'))();
       default:
-        throw new Error('지원하지 않는 형식의 로그인 입니다.');
+        return null;
     }
   }
 }

--- a/src/application/auth/guards/socialLogin.guard.ts
+++ b/src/application/auth/guards/socialLogin.guard.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { ExecutionContext, CanActivate } from '@nestjs/common';
+import { KakaoStrategy } from '../strategies/kakao.strategy';
+
+@Injectable()
+export class SocialLoginGuard implements CanActivate {
+  constructor(
+    private readonly kakaoLoginStrategy: KakaoStrategy,
+  ) { }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+    const provider = req.body.provider;
+
+    switch (provider) {
+      case "kakao":
+        await this.kakaoLoginStrategy.authenticate(req);
+        return true;
+      default:
+        throw new Error('지원하지 않는 형식의 로그인 입니다.');
+    }
+  }
+}

--- a/src/application/auth/strategies/jwtAccess.strategy.ts
+++ b/src/application/auth/strategies/jwtAccess.strategy.ts
@@ -1,0 +1,18 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy, ExtractJwt } from 'passport-jwt';
+import { JwtPayload } from "jsonwebtoken";
+
+@Injectable()
+export class JwtAccessStrategy extends PassportStrategy(Strategy, 'jwt-access') {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: process.env.JWT_ACCESS_SECRET,
+    });
+  }
+
+  async validate(payload: JwtPayload) {
+    return { id: payload.sub };
+  }
+}

--- a/src/application/auth/strategies/jwtRefresh.strategy.ts
+++ b/src/application/auth/strategies/jwtRefresh.strategy.ts
@@ -18,6 +18,6 @@ export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'jwt-refresh'
   }
 
   async validate(payload: JwtPayload) {
-    return { id: payload.id }
+    return { id: payload.sub }
   }
 }

--- a/src/application/auth/strategies/jwtRefresh.strategy.ts
+++ b/src/application/auth/strategies/jwtRefresh.strategy.ts
@@ -1,0 +1,23 @@
+import { Injectable } from "@nestjs/common";
+import { PassportStrategy } from "@nestjs/passport";
+import { JwtPayload } from "jsonwebtoken";
+import { ExtractJwt, Strategy } from "passport-jwt";
+
+@Injectable()
+export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
+  constructor(
+
+  ) {
+    super({
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (request) => { return request?.cookies?.['refresh-token'] }
+      ]),
+      secretOrKey: process.env.JWT_REFRESH_SECRET,
+      passReqToCallback: true
+    });
+  }
+
+  async validate(payload: JwtPayload) {
+    return { id: payload.id }
+  }
+}

--- a/src/application/auth/strategies/kakao.strategy.ts
+++ b/src/application/auth/strategies/kakao.strategy.ts
@@ -1,0 +1,51 @@
+import { BadRequestException, Injectable, NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { PassportStrategy } from "@nestjs/passport";
+import axios from "axios";
+import { Request } from "express";
+import { Strategy } from "passport-strategy";
+
+@Injectable()
+export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
+  constructor() {
+    super();
+  }
+
+  async authenticate(req: Request) {
+    const { code } = req.body;
+    try{
+      const kakaoToken = await this.getKakaoToken(code);
+      const oauthId = (await this.getKakaoUserInfo(kakaoToken)).toString();
+
+      this.success(oauthId);
+    } catch (error) {
+      this.fail(401);
+    }
+  }
+
+  private async getKakaoToken(code: string): Promise<string> {
+    const params = {
+      grant_type: 'authorization_code',
+      client_id: process.env.KAKAO_CLIENT_ID,
+      redirect_uri: process.env.KAKAO_CALLBACK_URL,
+      code: code
+    }
+    const headers = { 'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8' };
+    const res = await axios.post('https://kauth.kakao.com/oauth/token', {}, { params, headers });
+    if (!res) throw new BadRequestException('Kakao access token을 가져오는데 실패 했습니다.');
+
+    const kakaoToken = res.data.access_token;
+    if (!kakaoToken) throw new UnauthorizedException("Kakao access token을 가져오는데 실패 했습니다.");
+
+    return kakaoToken;
+  }
+
+  private async getKakaoUserInfo(kakaoToken: string): Promise<string> {
+    const res = await axios.get('https://kapi.kakao.com/v2/user/me', { headers: { Authorization: `Bearer ${kakaoToken}` } });
+    if (!res) new UnauthorizedException("소셜 로그인 계정 정보를 불러올 수 없습니다.");
+
+    const id = res.data.id;
+    if (!id) throw new NotFoundException("존재하지 않는 소셜 로그인 유저 입니다.");
+
+    return id;
+  }
+}

--- a/src/common/decorators/user.decorator.ts
+++ b/src/common/decorators/user.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const User = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);

--- a/src/common/interfaces/user.payload.ts
+++ b/src/common/interfaces/user.payload.ts
@@ -1,0 +1,3 @@
+export interface UserPayload {
+  id: number;
+}

--- a/src/domain/user/entities/user.entity.ts
+++ b/src/domain/user/entities/user.entity.ts
@@ -24,6 +24,6 @@ export class User {
   @Column({ default: true })
   isOnboarding: boolean;
 
-  @CreateDateColumn({ default: true })
+  @CreateDateColumn()
   createdAt: Date;
 }

--- a/src/domain/user/user.service.ts
+++ b/src/domain/user/user.service.ts
@@ -33,6 +33,7 @@ export class UserService {
     user.phone = phone || user.phone;
     user.bank = bank || user.bank;
     user.account = account || user.account;
+    user.isOnboarding = false
 
     await this.userRepository.save(user);
 

--- a/src/domain/user/user.service.ts
+++ b/src/domain/user/user.service.ts
@@ -26,7 +26,7 @@ export class UserService {
     if (!user) throw new NotFoundException("존재하지 않는 사용자 입니다.");
 
     const { name, phone, bank, account } = updateUserDto;
-    const phoneCheck = this.userRepository.findOne({ where: { phone } });
+    const phoneCheck = await this.userRepository.findOne({ where: { phone } });
     if (phoneCheck) throw new ConflictException("중복된 전화번호 입니다.");
 
     user.name = name || user.name;

--- a/src/domain/user/user.service.ts
+++ b/src/domain/user/user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
 import { Repository } from 'typeorm';
@@ -26,6 +26,8 @@ export class UserService {
     if (!user) throw new NotFoundException("존재하지 않는 사용자 입니다.");
 
     const { name, phone, bank, account } = updateUserDto;
+    const phoneCheck = this.userRepository.findOne({ where: { phone } });
+    if (phoneCheck) throw new ConflictException("중복된 전화번호 입니다.");
 
     user.name = name || user.name;
     user.phone = phone || user.phone;


### PR DESCRIPTION
**작업내용**

- 회원가입
    - 입력된 정보들을 body로 받아 회원 가입 진행
    - 성공 시 access token 반환 및 refresh-token cookie 설정
    - 성공 시 onboarding 상태 변경

- 로그아웃
    -  refresh-token cookie clear.

- 토큰 갱신
    - 유효한 refresh token인 경우 access token 반환
    - 유효하지 않으면 401

- refresh-token, access token strategy 구현
    - refresh token: cookie에서 가져와 검증
    - access token: header에서 가져와 검증

- kakao login 로직 strategy 및 guard로 분리
    - 원래 auth.service에 있었으나, 코드 분할과 기능 상 strategy로 빼면 좋겠다고 생각.
    - auth/social login api에 SocialLoginGuard 적용 -> provider에 따라 각 social login strategy 실행 -> 인증 과정
 
- decorator 추가
    - user decorator: @User() user: UserPayload. Req에서 user id 가져올 때 사용
    - cookie decorator: @Cookie('쿠키명'). 쿠키 정보 가져올 때 사용
